### PR TITLE
Add MTI tag to counter metrics for transaction type identification

### DIFF
--- a/jpos/src/main/java/org/jpos/metrics/MeterFactory.java
+++ b/jpos/src/main/java/org/jpos/metrics/MeterFactory.java
@@ -52,6 +52,10 @@ public class MeterFactory {
           () -> Counter.builder(meterInfo.id()).tags(meterInfo.add(tags)).description(meterInfo.description()).register(registry));
     }
 
+    public static Counter updateCounter(MeterRegistry registry, MeterInfo meterInfo, Tags tags) {
+        return Counter.builder(meterInfo.id()).tags(meterInfo.add(tags)).description(meterInfo.description()).register(registry);
+    }
+
     public static Gauge gauge(MeterRegistry registry, MeterInfo meterInfo, Tags tags, String unit, Supplier<Number> n) {
         return createMeter(registry, meterInfo, tags,
           () -> Gauge.builder(meterInfo.id(), n)

--- a/jpos/src/main/java/org/jpos/q2/iso/QServer.java
+++ b/jpos/src/main/java/org/jpos/q2/iso/QServer.java
@@ -414,16 +414,18 @@ public class QServer
               BaseUnits.THREADS,
               server::getConnectionCount
           );
-        msgInCounter = MeterFactory.counter(registry, MeterInfo.ISOMSG_IN, tags);
-        msgOutCounter = MeterFactory.counter(registry, MeterInfo.ISOMSG_OUT, tags);
         if (channel instanceof BaseChannel baseChannel) {
              baseChannel.setCounters(msgInCounter, msgOutCounter);
+             baseChannel.setMeterRegistry(registry);
+             baseChannel.setServerName(getName());
         }
     }
     private void removeMeters() {
         var registry = getServer().getMeterRegistry();
          registry.remove(connectionsGauge);
-         registry.remove(msgInCounter);
-         registry.remove(msgOutCounter);
+        if (msgInCounter != null)
+            registry.remove(msgInCounter);
+         if (msgOutCounter != null)
+            registry.remove(msgOutCounter);
     }
 }


### PR DESCRIPTION
Each counter metric now includes the Message Type Identifier (MTI) as a tag, enabling better classification, grouping, and filtering of metrics by transaction type. This enhancement improves monitoring and observability by providing clearer insights into the volume and distribution of different transaction types (e.g., Authorizations vs Reversals).

Example of the updated metrics output:

```
# HELP jpos_isomsg_total Received messages
# TYPE jpos_isomsg_total counter
jpos_isomsg_total{direction="in",mti="2100",name="gateway",type="server"} 250000.0
jpos_isomsg_total{direction="in",mti="2400",name="gateway",type="server"} 150000.0
jpos_isomsg_total{direction="out",mti="2110",name="gateway",type="server"} 250000.0
jpos_isomsg_total{direction="out",mti="2410",name="gateway",type="server"} 150000.0
```

